### PR TITLE
Add shared themeable UI styling

### DIFF
--- a/src/blackthorn_arena_reforged_save_editor_zh.py
+++ b/src/blackthorn_arena_reforged_save_editor_zh.py
@@ -23,6 +23,8 @@ import time
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 
+from ui_style import init_style, apply_palette as style_apply_palette
+
 APP_TITLE = "黑荊棘角鬥場：重鑄版 存檔修改器（JSON）"
 DEFAULT_FILENAME = "sav.dat"
 
@@ -32,16 +34,6 @@ def safe_int(v, default=None):
         return int(v)
     except Exception:
         return default
-
-def prefers_msjh():
-    # 嘗試使用微軟正黑體（Windows 常見），否則用系統預設
-    try:
-        import tkinter.font as tkfont
-        fams = set(tkfont.families())
-        return "Microsoft JhengHei UI" if "Microsoft JhengHei UI" in fams else (
-               "Microsoft JhengHei" if "Microsoft JhengHei" in fams else None)
-    except Exception:
-        return None
 
 # ---------- 資料模型 ----------
 class SaveModel:
@@ -127,30 +119,11 @@ class App(tk.Tk):
         except Exception:
             pass
 
-        # 風格
-        self.style = ttk.Style()
-        try:
-            self.style.theme_use("clam")
-        except Exception:
-            pass
-
-        # 字體
-        fn = prefers_msjh()
-        base_font = (fn or "TkDefaultFont", 11)
-        header_font = (fn or "TkDefaultFont", 12, "bold")
-        # 樣式細節
-        self.style.configure("Treeview", font=base_font, rowheight=28)
-        self.style.configure("Treeview.Heading", font=header_font)
-        self.style.map("Treeview", background=[("selected", "#0e639c")], foreground=[("selected", "white")])
-        self.style.configure("TButton", font=base_font, padding=6)
-        self.style.configure("TLabel", font=base_font)
-        self.style.configure("TEntry", font=base_font)
-        self.style.configure("TCheckbutton", font=base_font)
-        self.style.configure("TRadiobutton", font=base_font)
-
-        # 主題（亮/暗）
+        # 風格與主題
+        self.style = init_style(self)
         self.theme_var = tk.StringVar(value="亮色")
-        self.apply_palette("亮色")
+        self.tag_colors = {}
+        self.apply_palette(self.theme_var.get())
 
         # 內部狀態
         self.model = SaveModel()
@@ -192,30 +165,7 @@ class App(tk.Tk):
 
     # --------- 主題配色 ---------
     def apply_palette(self, kind):
-        if kind == "暗色":
-            bg = "#1e1e1e"
-            fg = "#e6e6e6"
-            panel = "#252526"
-            accent = "#0e639c"
-            alt = "#2a2a2a"
-        else:
-            bg = "#fafafa"
-            fg = "#202020"
-            panel = "#ffffff"
-            accent = "#0e639c"
-            alt = "#f0f3f8"
-
-        self.configure(bg=bg)
-        self.style.configure(".", background=bg, foreground=fg)
-        self.style.configure("Card.TFrame", background=panel, relief="flat")
-        self.style.configure("CardTitle.TLabel", background=panel, foreground=fg, font=("TkDefaultFont", 12, "bold"))
-        self.style.configure("Hint.TLabel", background=panel, foreground="#666666")
-        # Tree zebra
-        self.tag_colors = {
-            "even": alt,
-            "odd": panel,
-            "match": "#fff2ab" if kind != "暗色" else "#4d3f00"
-        }
+        self.tag_colors = style_apply_palette(self, self.style, kind)
 
     # ---------- UI ----------
     def create_menu(self):

--- a/src/ui_style.py
+++ b/src/ui_style.py
@@ -1,0 +1,70 @@
+import tkinter as tk
+from tkinter import ttk
+
+def prefers_msjh():
+    """Return Microsoft JhengHei font if available (commonly on Windows)."""
+    try:
+        import tkinter.font as tkfont
+        fams = set(tkfont.families())
+        if "Microsoft JhengHei UI" in fams:
+            return "Microsoft JhengHei UI"
+        if "Microsoft JhengHei" in fams:
+            return "Microsoft JhengHei"
+    except Exception:
+        pass
+    return None
+
+def init_style(root):
+    """Initialize ttk.Style with larger fonts and row height."""
+    style = ttk.Style()
+    try:
+        style.theme_use("clam")
+    except Exception:
+        pass
+
+    fn = prefers_msjh()
+    base_font = (fn or "TkDefaultFont", 11)
+    header_font = (fn or "TkDefaultFont", 12, "bold")
+
+    style.configure("Treeview", font=base_font, rowheight=28)
+    style.configure("Treeview.Heading", font=header_font)
+    style.map("Treeview", background=[("selected", "#0e639c")], foreground=[("selected", "white")])
+    style.configure("TButton", font=base_font, padding=6)
+    style.configure("TLabel", font=base_font)
+    style.configure("TEntry", font=base_font)
+    style.configure("TCheckbutton", font=base_font)
+    style.configure("TRadiobutton", font=base_font)
+
+    return style
+
+def apply_palette(root, style, kind):
+    """Apply light or dark palette. Returns tag colors for tree rows."""
+    k = str(kind).lower()
+    if k in ("dark", "\u6697\u8272"):  # "暗色"
+        bg = "#1e1e1e"
+        fg = "#e6e6e6"
+        panel = "#252526"
+        accent = "#0e639c"
+        alt = "#2a2a2a"
+    else:
+        bg = "#fafafa"
+        fg = "#202020"
+        panel = "#ffffff"
+        accent = "#0e639c"
+        alt = "#f0f3f8"
+
+    root.configure(bg=bg)
+    style.configure(".", background=bg, foreground=fg)
+    style.configure("Card.TFrame", background=panel, relief="flat")
+    style.configure("CardTitle.TLabel", background=panel, foreground=fg, font=("TkDefaultFont", 12, "bold"))
+    style.configure("Hint.TLabel", background=panel, foreground="#666666")
+    # Labelframe styling for apps that use it
+    style.configure("TLabelframe", background=panel, foreground=fg)
+    style.configure("TLabelframe.Label", background=panel, foreground=fg, font=("TkDefaultFont", 12, "bold"))
+
+    tag_colors = {
+        "even": alt,
+        "odd": panel,
+        "match": "#fff2ab" if k not in ("dark", "\u6697\u8272") else "#4d3f00",
+    }
+    return tag_colors


### PR DESCRIPTION
## Summary
- Extract common font, row height, and palette setup into `ui_style` helper
- Apply configurable light/dark themes in English editor via new View menu
- Reuse shared style in Chinese interface for consistent appearance

## Testing
- `python -m py_compile src/ui_style.py src/blackthorn_arena_reforged_save_editor.py src/blackthorn_arena_reforged_save_editor_zh.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a32a44f483339434d5fb88b83096