### PR TITLE
Add notebook tabs with card layout

### DIFF
--- a/src/blackthorn_arena_reforged_save_editor.py
+++ b/src/blackthorn_arena_reforged_save_editor.py
@@ -28,7 +28,7 @@ import time
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 
-from ui_style import init_style, apply_palette as style_apply_palette
+from ui_style import init_style, apply_palette as style_apply_palette, card as style_card
 
 APP_TITLE = "Blackthorn Arena: Reforged - Save Editor (JSON)"
 DEFAULT_FILENAME = "sav.dat"
@@ -205,30 +205,34 @@ class App(tk.Tk):
         root = ttk.Frame(self, padding=8)
         root.pack(fill="both", expand=True)
 
-        # Top meta editor (gold/rep + toggles)
-        meta = ttk.LabelFrame(root, text="Meta")
-        meta.pack(fill="x", pady=(0,8))
+        nb = ttk.Notebook(root)
+        nb.pack(fill="both", expand=True)
 
-        ttk.Checkbutton(meta, text="Show ALL NPCs (not just team 0)",
-                        variable=self.show_all_var, command=self.refresh_table).pack(side="left", padx=(8,8))
-
-        ttk.Label(meta, text="Search name:").pack(side="left")
-        ttk.Entry(meta, textvariable=self.search_var, width=20).pack(side="left", padx=(4,10))
-        ttk.Label(meta, text="Min level:").pack(side="left")
-        ttk.Entry(meta, textvariable=self.filter_min_level_var, width=6).pack(side="left", padx=(4,10))
-        ttk.Button(meta, text="Apply Filters", command=self.refresh_table).pack(side="left", padx=(4,12))
-
-        sep = ttk.Separator(meta, orient="vertical")
-        sep.pack(side="left", fill="y", padx=8, pady=4)
-
+        # ----- General Tab -----
+        tab_gen = ttk.Frame(nb)
+        nb.add(tab_gen, text="General")
+        meta = style_card(tab_gen, "Meta")
         ttk.Label(meta, text="Wealth (Gold):").pack(side="left")
         ttk.Entry(meta, textvariable=self.gold_var, width=8).pack(side="left", padx=(4,10))
         ttk.Label(meta, text="Reputation:").pack(side="left")
         ttk.Entry(meta, textvariable=self.rep_var, width=8).pack(side="left", padx=(4,10))
         ttk.Button(meta, text="Update Meta", command=self.on_update_meta).pack(side="left", padx=(4,8))
 
-        # Table
-        table_frame = ttk.Frame(root)
+        # ----- Gladiators Tab -----
+        tab_glad = ttk.Frame(nb)
+        nb.add(tab_glad, text="Gladiators")
+
+        filters = style_card(tab_glad, "Filters")
+        ttk.Checkbutton(filters, text="Show ALL NPCs (not just team 0)",
+                        variable=self.show_all_var, command=self.refresh_table).pack(side="left", padx=(8,8))
+        ttk.Label(filters, text="Search name:").pack(side="left")
+        ttk.Entry(filters, textvariable=self.search_var, width=20).pack(side="left", padx=(4,10))
+        ttk.Label(filters, text="Min level:").pack(side="left")
+        ttk.Entry(filters, textvariable=self.filter_min_level_var, width=6).pack(side="left", padx=(4,10))
+        ttk.Button(filters, text="Apply Filters", command=self.refresh_table).pack(side="left", padx=(4,12))
+
+        table_card = style_card(tab_glad, "Roster")
+        table_frame = ttk.Frame(table_card)
         table_frame.pack(fill="both", expand=True)
 
         columns = ("idx","id","unitId","team","unitname","level","potentialPoint","skillPoint","livingSkillPoint")
@@ -242,10 +246,7 @@ class App(tk.Tk):
         self.tree.configure(yscroll=yscroll.set)
         yscroll.pack(side="right", fill="y")
 
-        # Editor panel
-        editor = ttk.LabelFrame(root, text="Edit Selected Gladiators")
-        editor.pack(fill="x", pady=(8,0))
-
+        editor = style_card(tab_glad, "Edit Selected Gladiators")
         grid = ttk.Frame(editor)
         grid.pack(fill="x", padx=8, pady=4)
 
@@ -266,6 +267,19 @@ class App(tk.Tk):
         ttk.Button(grid, text="Apply to Selected", command=self.on_apply_selected).grid(row=r, column=3, sticky="w", padx=8, pady=(6,0))
 
         ttk.Label(editor, text="Hints: Use modest numbers first (e.g., +5 to +10 points) to avoid breaking balance. Back up your save!").pack(anchor="w", padx=8, pady=(2,8))
+
+        # ----- Placeholder Tabs -----
+        tab_traits = ttk.Frame(nb)
+        nb.add(tab_traits, text="Traits")
+        style_card(tab_traits, "Coming soon")
+
+        tab_items = ttk.Frame(nb)
+        nb.add(tab_items, text="Items")
+        style_card(tab_items, "Coming soon")
+
+        tab_arena = ttk.Frame(nb)
+        nb.add(tab_arena, text="Arena")
+        style_card(tab_arena, "Coming soon")
 
     # ---------- Menu actions ----------
     def on_open(self):

--- a/src/blackthorn_arena_reforged_save_editor_zh.py
+++ b/src/blackthorn_arena_reforged_save_editor_zh.py
@@ -23,7 +23,7 @@ import time
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 
-from ui_style import init_style, apply_palette as style_apply_palette
+from ui_style import init_style, apply_palette as style_apply_palette, card as style_card
 
 APP_TITLE = "黑荊棘角鬥場：重鑄版 存檔修改器（JSON）"
 DEFAULT_FILENAME = "sav.dat"
@@ -216,27 +216,36 @@ class App(tk.Tk):
         mbar.add_cascade(label="說明", menu=helpm)
         self.config(menu=mbar)
 
-    def card(self, parent, title=None):
-        frame = ttk.Frame(parent, style="Card.TFrame", padding=(10,10,10,10))
-        frame.pack(fill="x", pady=(0,8))
-        if title:
-            ttk.Label(frame, text=title, style="CardTitle.TLabel").pack(anchor="w", pady=(0,6))
-        return frame
-
     def create_widgets(self):
         root = ttk.Frame(self, padding=10)
         root.pack(fill="both", expand=True)
 
-        # 外觀/主題列
-        topbar = self.card(root)
+        nb = ttk.Notebook(root)
+        nb.pack(fill="both", expand=True)
+
+        # -------- 通用 --------
+        tab_general = ttk.Frame(nb)
+        nb.add(tab_general, text="通用")
+
+        topbar = style_card(tab_general)
         ttk.Label(topbar, text="外觀：", width=6).pack(side="left")
         ttk.OptionMenu(topbar, self.theme_var, self.theme_var.get(), "亮色", "暗色", command=self.on_theme_change).pack(side="left", padx=(0,10))
         ttk.Label(topbar, text="（可在「視圖」選單調整介面縮放）", style="Hint.TLabel").pack(side="left")
 
-        # 全局屬性 + 篩選
-        meta = self.card(root, "全局屬性 / 篩選")
-        # 行1：篩選控制
-        row1 = ttk.Frame(meta)
+        meta = style_card(tab_general, "全局屬性")
+        ttk.Label(meta, text="金錢 (wealth)：").pack(side="left")
+        ttk.Entry(meta, textvariable=self.gold_var, width=10).pack(side="left", padx=(4,12))
+        ttk.Label(meta, text="聲望 (reputation)：").pack(side="left")
+        ttk.Entry(meta, textvariable=self.rep_var, width=10).pack(side="left", padx=(4,12))
+        ttk.Button(meta, text="更新全局屬性", command=self.on_update_meta).pack(side="left")
+        ttk.Label(meta, text="提示：修改後記得到【檔案→儲存】寫回存檔（會自動備份）", style="Hint.TLabel").pack(anchor="w", pady=(6,0))
+
+        # -------- 角鬥士 --------
+        tab_glad = ttk.Frame(nb)
+        nb.add(tab_glad, text="角鬥士")
+
+        filt = style_card(tab_glad, "篩選")
+        row1 = ttk.Frame(filt)
         row1.pack(fill="x", pady=4)
         ttk.Checkbutton(row1, text="只顯示玩家隊伍 (team=0)", variable=self.show_only_player_var, command=self.refresh_table).pack(side="left")
         ttk.Checkbutton(row1, text="只顯示名字含底線 _", variable=self.only_underscore_var, command=self.refresh_table).pack(side="left", padx=(10,0))
@@ -246,18 +255,7 @@ class App(tk.Tk):
         ttk.Entry(row1, textvariable=self.filter_min_level_var, width=6).pack(side="left", padx=(4,6))
         ttk.Button(row1, text="套用篩選", command=self.refresh_table).pack(side="left", padx=(8,0))
 
-        # 行2：全局屬性
-        row2 = ttk.Frame(meta)
-        row2.pack(fill="x", pady=4)
-        ttk.Label(row2, text="金錢 (wealth)：").pack(side="left")
-        ttk.Entry(row2, textvariable=self.gold_var, width=10).pack(side="left", padx=(4,12))
-        ttk.Label(row2, text="聲望 (reputation)：").pack(side="left")
-        ttk.Entry(row2, textvariable=self.rep_var, width=10).pack(side="left", padx=(4,12))
-        ttk.Button(row2, text="更新全局屬性", command=self.on_update_meta).pack(side="left")
-        ttk.Label(meta, text="提示：修改後記得到【檔案→儲存】寫回存檔（會自動備份）", style="Hint.TLabel").pack(anchor="w", pady=(6,0))
-
-        # 表格
-        table_card = self.card(root, "角鬥士清單")
+        table_card = style_card(tab_glad, "角鬥士清單")
         table_frame = ttk.Frame(table_card)
         table_frame.pack(fill="both", expand=True)
 
@@ -278,8 +276,7 @@ class App(tk.Tk):
         self.tree.configure(yscroll=yscroll.set)
         yscroll.pack(side="right", fill="y")
 
-        # 編輯面板
-        editor = self.card(root, "批次編輯（套用至選取的角色）")
+        editor = style_card(tab_glad, "批次編輯（套用至選取的角色）")
         grid = ttk.Frame(editor)
         grid.pack(fill="x", padx=2, pady=2)
 
@@ -300,6 +297,19 @@ class App(tk.Tk):
         ttk.Button(grid, text="套用到選取", command=self.on_apply_selected).grid(row=r, column=3, sticky="w", padx=10, pady=(8,0))
 
         ttk.Label(editor, text="建議：先用「加值」小幅調整（+5～+10），避免過度破壞平衡。", style="Hint.TLabel").pack(anchor="w", pady=(6,0))
+
+        # -------- 其他分頁 --------
+        tab_traits = ttk.Frame(nb)
+        nb.add(tab_traits, text="特性")
+        style_card(tab_traits, "尚未實作")
+
+        tab_items = ttk.Frame(nb)
+        nb.add(tab_items, text="物品")
+        style_card(tab_items, "尚未實作")
+
+        tab_arena = ttk.Frame(nb)
+        nb.add(tab_arena, text="競技場")
+        style_card(tab_arena, "尚未實作")
 
     # ---------- 事件 ----------
     def on_theme_change(self, *_):

--- a/src/ui_style.py
+++ b/src/ui_style.py
@@ -58,6 +58,12 @@ def apply_palette(root, style, kind):
     style.configure("Card.TFrame", background=panel, relief="flat")
     style.configure("CardTitle.TLabel", background=panel, foreground=fg, font=("TkDefaultFont", 12, "bold"))
     style.configure("Hint.TLabel", background=panel, foreground="#666666")
+    # Notebook / tabs
+    style.configure("TNotebook", background=bg, borderwidth=0)
+    style.configure("TNotebook.Tab", background=alt, foreground=fg, padding=(10, 6))
+    style.map("TNotebook.Tab",
+               background=[("selected", panel), ("!selected", alt)],
+               foreground=[("selected", fg), ("!selected", fg)])
     # Labelframe styling for apps that use it
     style.configure("TLabelframe", background=panel, foreground=fg)
     style.configure("TLabelframe.Label", background=panel, foreground=fg, font=("TkDefaultFont", 12, "bold"))
@@ -68,3 +74,14 @@ def apply_palette(root, style, kind):
         "match": "#fff2ab" if k not in ("dark", "\u6697\u8272") else "#4d3f00",
     }
     return tag_colors
+
+
+def card(parent, title=None, **pack):
+    """Create a styled card frame with optional title and standard padding."""
+    frame = ttk.Frame(parent, style="Card.TFrame", padding=(10, 10, 10, 10))
+    if not pack:
+        pack = {"fill": "x", "pady": (0, 8)}
+    frame.pack(**pack)
+    if title:
+        ttk.Label(frame, text=title, style="CardTitle.TLabel").pack(anchor="w", pady=(0, 6))
+    return frame


### PR DESCRIPTION
## Summary
- Introduce reusable `ui_style.card` helper and notebook styling
- Move meta editor and roster into new notebook tabs
- Stub out traits, items, and arena tabs for future features

## Testing
- `python -m py_compile src/blackthorn_arena_reforged_save_editor.py src/blackthorn_arena_reforged_save_editor_zh.py src/ui_style.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8cfacbf0c8333b28cc222910678d9