### PR TITLE
Handle missing customtkinter dependency

### DIFF
--- a/src/blackthorn_arena_reforged_save_editor_zh.py
+++ b/src/blackthorn_arena_reforged_save_editor_zh.py
@@ -17,12 +17,19 @@ BSagility、BSprecision、BSintelligence、BSwillpower）
 """
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import json
 import os
 import time
 from typing import Dict, List, Tuple
 
-import customtkinter as ctk
+if importlib.util.find_spec("customtkinter") is None:
+    raise SystemExit(
+        "找不到 customtkinter 模組，請先執行 `pip install customtkinter` 後再啟動。"
+    )
+
+ctk = importlib.import_module("customtkinter")
 from tkinter import filedialog, messagebox
 
 APP_TITLE = "黑荊棘角鬥場：重鑄版 存檔修改器（JSON）"


### PR DESCRIPTION
## Summary
- detect whether the customtkinter module is available before starting the Traditional Chinese UI
- show a clear installation hint and exit gracefully when the dependency is missing

## Testing
- python src/blackthorn_arena_reforged_save_editor_zh.py

------
https://chatgpt.com/codex/tasks/task_e_68d060a41e708333b402c7b7aabe0bdd